### PR TITLE
Bugfix and old links removal

### DIFF
--- a/INRIM_SRC.ny
+++ b/INRIM_SRC.ny
@@ -12,7 +12,7 @@
 ;control anno "Anno" int "" 88 0 99
 ;control mese "Mese" int "" 4 1 12
 ;control giorno "Giorno" int "" 22 1 31
-;control settimana "Nome giorno" choice "Lun.,Mart.,Merc.,Giov.,Ven.,Sabato,Domenica" "Sabato"
+;control settimana "Nome del giorno" choice "Lun.,Mart.,Merc.,Giov.,Ven.,Sabato,Domenica" "Sabato"
 
 ;; Controlli impostazione orario
 ;control ore "Ora" int "" 19 0 23

--- a/INRIM_SRC.ny
+++ b/INRIM_SRC.ny
@@ -3,7 +3,7 @@
 ;type generate
 ;name "Segnale Orario SRC..."
 ;action "Generazione del segnale SRC..."
-;info "Generatore di segnale orario RAI-SRC.\nPer maggiori info visitare il sito dell'INRiM all'indirizzo http://www.inrim.it/res/tf/src_i.shtml\n\nPer utilizzare questo segnale in maniera corretta si deve fare in modo che l'inizio dell'ultimo segnale\nacustico corrisponda all'inizio del minuto successivo a cui il segnale fa riferimento;\nequivalentemente l'inizio del suono generato deve essere allineato con il secondo 52 del minuto corrente.\n\nPlug-in rilasciato con licenza GPL 2 da David Costa <david@zarel.net>.\nRealizzato per O.R.S.A. Officine Radiotecniche Società Anonima."
+;info "Generatore di segnale orario RAI-SRC.\nPer maggiori informazioni visitare la pagina dedicata su Wikipedia disponibile al seguente link: https://it.wikipedia.org/wiki/Segnale_orario\n\nPer utilizzare questo segnale in maniera corretta si deve fare in modo che l'inizio dell'ultimo segnale\nacustico corrisponda all'inizio del minuto successivo a cui il segnale fa riferimento;\nequivalentemente l'inizio del suono generato deve essere allineato con il secondo 52 del minuto corrente.\n\nPlug-in rilasciato con licenza GPL 2 da David Costa <david@zarel.net>.\nRealizzato per O.R.S.A. Officine Radiotecniche Società Anonima."
 
 ;; I controlli sono organizzati per tipo
 ;; Data - Ora - Avvisi
@@ -12,16 +12,16 @@
 ;control anno "Anno" int "" 88 0 99
 ;control mese "Mese" int "" 4 1 12
 ;control giorno "Giorno" int "" 22 1 31
-;control settimana "Nome giorno" choice "lunedì,martedì,mercoledì,giovedì,venerdì,sabato,domenica" "venerdì"
+;control settimana "Nome giorno" choice "Lun.,Mart.,Merc.,Giov.,Ven.,Sabato,Domenica" "Sabato"
 
 ;; Controlli impostazione orario
 ;control ore "Ora" int "" 19 0 23
-;control minuti "Minuto" int "" 0 0 59
+;control minuti "Minuti" int "" 0 0 59
 ;control legale "Ora estiva (DST)" choice "Ora legale,Ora solare" "Ora solare"
 
 ;; Controlli sugli avvisi
 ;control avviso-legale "Avviso cambio DST" choice "Nessun cambio nei prossimi 7 giorni,Previsto un cambio entro i prossimi 6 giorni,Previsto un cambio entro i prossimi 5 giorni,Previsto un cambio entro i prossimi 4 giorni,Previsto un cambio entro i prossimi 3 giorni,Previsto un cambio entro i prossimi 2 giorni,Previsto un cambio entro un giorno,Cambio all'ora solare (02.00)/legale(03.00) oggi" "Nessun cambio nei prossimi 7 giorni"
-;control avviso-intercalare "Avviso secondo intercalare" choice "Nessuno previsto,Anticipo di 1s a fine mese,Ritardo di 1s a fine mese" "Nessuno previsto"
+;control avviso-intercalare "Avviso secondo intercalare" choice "Nessuno previsto,Anticipo di 1 secondo alla fine del mese,Ritardo di 1 secondo alla fine del mese" "Nessuno previsto"
 
 ;; Converte secondi in millisecondi
 (defun ms (value) (* 0.001 value))
@@ -69,7 +69,7 @@
   )
 
 ;; Modula una stringa binaria con FSK
-(defun fsk (stringa) 
+(defun fsk (stringa)
   (seqrep (i (length stringa))
 		  (render-char (char stringa i))
 		  )
@@ -209,4 +209,3 @@
   (s-rest (ms 1900))
   (beep)
   )
-

--- a/INRIM_SRC.ny
+++ b/INRIM_SRC.ny
@@ -12,7 +12,7 @@
 ;control anno "Anno" int "" 88 0 99
 ;control mese "Mese" int "" 4 1 12
 ;control giorno "Giorno" int "" 22 1 31
-;control settimana "Nome del giorno" choice "Lun.,Mart.,Merc.,Giov.,Ven.,Sabato,Domenica" "Sabato"
+;control settimana "Nome del giorno" choice "Lun.,Mar.,Mer.,Gio.,Ven.,Sab.,Dom." "Ven."
 
 ;; Controlli impostazione orario
 ;control ore "Ora" int "" 19 0 23
@@ -20,7 +20,7 @@
 ;control legale "Ora estiva (DST)" choice "Ora legale,Ora solare" "Ora solare"
 
 ;; Controlli sugli avvisi
-;control avviso-legale "Avviso cambio DST" choice "Nessun cambio nei prossimi 7 giorni,Previsto un cambio entro i prossimi 6 giorni,Previsto un cambio entro i prossimi 5 giorni,Previsto un cambio entro i prossimi 4 giorni,Previsto un cambio entro i prossimi 3 giorni,Previsto un cambio entro i prossimi 2 giorni,Previsto un cambio entro un giorno,Cambio all'ora solare (02.00)/legale(03.00) oggi" "Nessun cambio nei prossimi 7 giorni"
+;control avviso-legale "Avviso cambio DST" choice "Nessun cambio nei prossimi 7 giorni,Previsto un cambio entro i prossimi 6 giorni,Previsto un cambio entro i prossimi 5 giorni,Previsto un cambio entro i prossimi 4 giorni,Previsto un cambio entro i prossimi 3 giorni,Previsto un cambio entro i prossimi 2 giorni,Previsto un cambio entro un giorno,Cambio dall'ora solare (02.00) a quella legale (03.00) o viceversa oggi" "Nessun cambio nei prossimi 7 giorni"
 ;control avviso-intercalare "Avviso secondo intercalare" choice "Nessuno previsto,Anticipo di 1 secondo alla fine del mese,Ritardo di 1 secondo alla fine del mese" "Nessuno previsto"
 
 ;; Converte secondi in millisecondi

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ Il programma è un plug-in per Audacity che genera un segnale orario RAI valido,
 
 Per installare il plugin è sufficiente copiare il file `INRIM_SRC.ny` in una directory nota ad Audacious: in Linux, per installare il plug-in a un singolo utente il file va copiato nella directory `~/.audacity-files/plug-ins/` (creandola se non esiste).
 
-In caso di dubbio consultare il manuale di audacity a questo indirizzo:
-
-http://wiki.audacityteam.org/wiki/Download_Nyquist_Plugins#Installing_Plugins
+In caso di dubbio consultare la [pagina dedicata del manuale di Audacity](http://wiki.audacityteam.org/wiki/Download_Nyquist_Plugins#Installing_Plugins).
 
 ## Utilizzo
 
@@ -25,3 +23,7 @@ Il programma è interamente distribuito con licenza GPL2 il cui testo completo �
 https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
 Per suggerimenti e feedback generale potete scrivermi all'indirizzo <david@zarel.net>
+
+## Maggiori informazioni
+
+Per maggiori informazioni sul Segnale RAI Codificato è possibile visitare la [pagina su Wikipedia](https://it.wikipedia.org/wiki/Segnale_orario)

--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ Per suggerimenti e feedback generale potete scrivermi all'indirizzo <david@zarel
 
 ## Maggiori informazioni
 
-Per maggiori informazioni sul Segnale RAI Codificato è possibile visitare la [pagina su Wikipedia](https://it.wikipedia.org/wiki/Segnale_orario)
+Per maggiori informazioni sul Segnale RAI Codificato è possibile visitare la [pagina su Wikipedia](https://it.wikipedia.org/wiki/Segnale_orario) oppure una versione archiviata della [pagina ufficiale](https://web.archive.org/web/20161223104950/http://www.inrim.it:80/res/tf/src_i.shtml) dal sito web dell'INRiM.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ L'audio così generato si sostituirà alla selezione esistente o verrà creata u
 
 ## Licenza e feedback
 
-Il programma è interamente distribuito con licenza GPL2 il cui testo completo è reperibile al seguente indirizzo
-
-https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+Il programma è interamente distribuito con licenza GPL2 il cui testo completo è reperibile [qui](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html)
 
 Per suggerimenti e feedback generale potete scrivermi all'indirizzo <david@zarel.net>
 


### PR DESCRIPTION
Rimosso il link al sito dell'INRiM dal file dato che il segnale orario non viene più generato da loro.
Aggiunto il link alla pagina di Wikipedia nel README.
I nomi dei giorni della settimana non venivano visualizzati correttamente:

![Giorni SRC old](https://user-images.githubusercontent.com/30187360/66229531-52f07b00-e6e2-11e9-88eb-4af991c5037f.PNG)

I nomi dei giorni sono quindi stati modificati per poter essere visualizzati correttamente.
Ora vengono visualizzati cosi:

![Giorni SRC new](https://user-images.githubusercontent.com/30187360/66229735-cb573c00-e6e2-11e9-8b90-d043080367a2.png)
